### PR TITLE
AO3-7044 Migrate taggings table to BIGINT

### DIFF
--- a/db/migrate/20251002101320_change_taggings_id_to_bigint.rb
+++ b/db/migrate/20251002101320_change_taggings_id_to_bigint.rb
@@ -1,0 +1,11 @@
+class ChangeTaggingsIdToBigint < ActiveRecord::Migration[7.1]
+  uses_departure! if Rails.env.staging? || Rails.env.production?
+
+  def up
+    change_column :taggings, :id, "bigint NOT NULL AUTO_INCREMENT"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "This migration cannot be reverted because we can't safely migrate to a smaller id"
+  end
+end


### PR DESCRIPTION
## Issue

https://otwarchive.atlassian.net/browse/AO3-7044

## Purpose

Migrates the taggings table primary key from integer to BIGINT to prevent integer overflow as the table grows. This is a preventive infrastructure improvement to handle the increasing volume of tags in the system.

## Testing Instructions

1. Run the migration in a development environment: `rails db:migrate`
2. Verify the schema change: Check that `taggings.id` column is now BIGINT type
3. Test tagging functionality: Ensure works can still be tagged and tags are properly associated
4. Run existing test suite to verify no functionality breaks

## References

This follows the same pattern as recent similar migrations:
- `20250704060231_change_bookmark_foreign_keys_type.rb` 
- `20250718220533_change_subscriptions_id_to_bigint.rb`

## Credit

Alyssa Powell (she/her)